### PR TITLE
fix: delete button works after returning from summary page

### DIFF
--- a/src/renderer/src/pages/ScanPage.jsx
+++ b/src/renderer/src/pages/ScanPage.jsx
@@ -140,7 +140,7 @@ export default function ScanPage() {
   }
 
   const resetLast = () => {
-    if (actionHistory.length === 0) return
+    if (cartItemsList.length === 0) return
 
     // Letztes Item aus cartItemsList entfernen
     setCartItemsList((prev) => {


### PR DESCRIPTION
resetLast() was guarded by actionHistory.length which resets to [] on component remount, while cartItemsList persists via sessionStorage. Changed guard to check cartItemsList.length instead.